### PR TITLE
Add better support for custom messages (WIP)

### DIFF
--- a/lib/integrations/ecto.ex
+++ b/lib/integrations/ecto.ex
@@ -1,8 +1,6 @@
 defmodule Freight.Integrations.Ecto do
   @moduledoc """
-  The ecto integration converts ecto changesets into error messages.
-
-  You can pass a changeset as an error message, and Freight will interpret it and list its errors.
+  The ecto integration converts Ecto changeset errors into error messages.
   """
 
   import Ecto.Changeset, only: [traverse_errors: 2]

--- a/lib/integrations/ecto.ex
+++ b/lib/integrations/ecto.ex
@@ -13,10 +13,11 @@ defmodule Freight.Integrations.Ecto do
   """
   def convert_error(%Changeset{} = changeset) do
     changeset
-    |> traverse_errors(&traverse_errors_map/1)
-    |> build_error_list()
+    |> traverse_errors(&traverse_errors_map/3)
+    |> build_error_list
   end
 
+  # converts to string without raising
   defp safe_to_string(term) do
     case String.Chars.impl_for(term) do
       nil -> inspect(term)
@@ -25,7 +26,20 @@ defmodule Freight.Integrations.Ecto do
   end
 
   # https://hexdocs.pm/ecto/Ecto.Changeset.html#traverse_errors/2
-  defp traverse_errors_map({msg, opts}) do
+  defp traverse_errors_map(_changeset, field, {msg, opts} = error) do
+    validation = Keyword.get(opts, :validation)
+
+    case is_custom_error_message?(validation, msg) do
+      true ->
+        reduce_options_onto_message(error)
+
+      false ->
+        msg = reduce_options_onto_message(error)
+        Enum.join([Atom.to_string(field), msg], " ")
+    end
+  end
+
+  defp reduce_options_onto_message({msg, opts}) do
     Enum.reduce(opts, msg, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", safe_to_string(value))
     end)
@@ -33,8 +47,32 @@ defmodule Freight.Integrations.Ecto do
 
   # maps key-value map where keys are field names and values are errors to a list
   defp build_error_list(map) do
-    Enum.map(map, fn {key, value} ->
-      Enum.join([Atom.to_string(key), value], " ")
-    end)
+    Enum.reduce(map, [], fn {_, value}, acc -> acc ++ value end)
   end
+
+  # to be honest, i don't know if this is the best way to see if there are custom errors.
+  # however i'm already in too deep now.
+  defp is_custom_error_message?(:acceptance, "must be accepted"), do: false
+  defp is_custom_error_message?(:confirmation, "does not match confirmation"), do: false
+  defp is_custom_error_message?(:exclusion, "is reserved"), do: false
+  defp is_custom_error_message?(:format, "has invalid format"), do: false
+  defp is_custom_error_message?(:inclusion, "is invalid"), do: false
+  defp is_custom_error_message?(:length, "should be %{count} character(s)"), do: false
+  defp is_custom_error_message?(:length, "should be %{count} byte(s)"), do: false
+  defp is_custom_error_message?(:length, "should be %{count} item(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at least %{count} character(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at least %{count} byte(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at least %{count} item(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at most %{count} character(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at most %{count} byte(s)"), do: false
+  defp is_custom_error_message?(:length, "should be at most %{count} item(s)"), do: false
+  defp is_custom_error_message?(:number, "must be less than %{number}"), do: false
+  defp is_custom_error_message?(:number, "must be greater than %{number}"), do: false
+  defp is_custom_error_message?(:number, "must be less than or equal to %{number}"), do: false
+  defp is_custom_error_message?(:number, "must be greater than or equal to %{number}"), do: false
+  defp is_custom_error_message?(:number, "must be equal to %{number}"), do: false
+  defp is_custom_error_message?(:number, "must be not equal to %{number}"), do: false
+  defp is_custom_error_message?(:required, "can't be blank"), do: false
+  defp is_custom_error_message?(:subset, "has an invalid entry"), do: false
+  defp is_custom_error_message?(_, _), do: true
 end

--- a/lib/integrations/ecto.ex
+++ b/lib/integrations/ecto.ex
@@ -8,6 +8,10 @@ defmodule Freight.Integrations.Ecto do
   import Ecto.Changeset, only: [traverse_errors: 2]
   alias Ecto.Changeset
 
+  @doc false
+  defdelegate is_custom_error_message?(atom, message),
+    to: Freight.Integrations.Ecto.IsCustomErrorMessage
+
   @doc """
   Converts a changeset to a list of error strings
   """
@@ -49,30 +53,4 @@ defmodule Freight.Integrations.Ecto do
   defp build_error_list(map) do
     Enum.reduce(map, [], fn {_, value}, acc -> acc ++ value end)
   end
-
-  # to be honest, i don't know if this is the best way to see if there are custom errors.
-  # however i'm already in too deep now.
-  defp is_custom_error_message?(:acceptance, "must be accepted"), do: false
-  defp is_custom_error_message?(:confirmation, "does not match confirmation"), do: false
-  defp is_custom_error_message?(:exclusion, "is reserved"), do: false
-  defp is_custom_error_message?(:format, "has invalid format"), do: false
-  defp is_custom_error_message?(:inclusion, "is invalid"), do: false
-  defp is_custom_error_message?(:length, "should be %{count} character(s)"), do: false
-  defp is_custom_error_message?(:length, "should be %{count} byte(s)"), do: false
-  defp is_custom_error_message?(:length, "should be %{count} item(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at least %{count} character(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at least %{count} byte(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at least %{count} item(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at most %{count} character(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at most %{count} byte(s)"), do: false
-  defp is_custom_error_message?(:length, "should be at most %{count} item(s)"), do: false
-  defp is_custom_error_message?(:number, "must be less than %{number}"), do: false
-  defp is_custom_error_message?(:number, "must be greater than %{number}"), do: false
-  defp is_custom_error_message?(:number, "must be less than or equal to %{number}"), do: false
-  defp is_custom_error_message?(:number, "must be greater than or equal to %{number}"), do: false
-  defp is_custom_error_message?(:number, "must be equal to %{number}"), do: false
-  defp is_custom_error_message?(:number, "must be not equal to %{number}"), do: false
-  defp is_custom_error_message?(:required, "can't be blank"), do: false
-  defp is_custom_error_message?(:subset, "has an invalid entry"), do: false
-  defp is_custom_error_message?(_, _), do: true
 end

--- a/lib/integrations/is_custom_error_message.ex
+++ b/lib/integrations/is_custom_error_message.ex
@@ -1,0 +1,31 @@
+defmodule Freight.Integrations.Ecto.IsCustomErrorMessage do
+  @moduledoc false
+
+  # to be honest, i don't know if this is the best way to see if there are custom errors.
+  # however i'm already in too deep now.
+  def is_custom_error_message?(:acceptance, "must be accepted"), do: false
+  def is_custom_error_message?(:confirmation, "does not match confirmation"), do: false
+  def is_custom_error_message?(:exclusion, "is reserved"), do: false
+  def is_custom_error_message?(:format, "has invalid format"), do: false
+  def is_custom_error_message?(:inclusion, "is invalid"), do: false
+  def is_custom_error_message?(:length, "should be %{count} character(s)"), do: false
+  def is_custom_error_message?(:length, "should be %{count} byte(s)"), do: false
+  def is_custom_error_message?(:length, "should be %{count} item(s)"), do: false
+  def is_custom_error_message?(:length, "should be at least %{count} character(s)"), do: false
+  def is_custom_error_message?(:length, "should be at least %{count} byte(s)"), do: false
+  def is_custom_error_message?(:length, "should be at least %{count} item(s)"), do: false
+  def is_custom_error_message?(:length, "should be at most %{count} character(s)"), do: false
+  def is_custom_error_message?(:length, "should be at most %{count} byte(s)"), do: false
+  def is_custom_error_message?(:length, "should be at most %{count} item(s)"), do: false
+  def is_custom_error_message?(:number, "must be less than %{number}"), do: false
+  def is_custom_error_message?(:number, "must be greater than %{number}"), do: false
+  def is_custom_error_message?(:number, "must be less than or equal to %{number}"), do: false
+  def is_custom_error_message?(:number, "must be greater than or equal to %{number}"), do: false
+  def is_custom_error_message?(:number, "must be equal to %{number}"), do: false
+  def is_custom_error_message?(:number, "must be not equal to %{number}"), do: false
+  def is_custom_error_message?(:required, "can't be blank"), do: false
+  def is_custom_error_message?(:subset, "has an invalid entry"), do: false
+  def is_custom_error_message?(:assoc, "is invalid"), do: false
+  def is_custom_error_message?(:embed, "is invalid"), do: false
+  def is_custom_error_message?(_, _), do: true
+end

--- a/test/unit/integrations/ecto_test.exs
+++ b/test/unit/integrations/ecto_test.exs
@@ -22,7 +22,7 @@ defmodule Freight.UnitTests.Integrations.EctoTest do
       |> cast(params, [:email, :name, :age])
       |> validate_required([:email, :name, :age])
       |> validate_length(:name, min: 2)
-      |> validate_inclusion(:age, 21..100)
+      |> validate_inclusion(:age, 21..100, message: "You are not old enough!")
     end
   end
 
@@ -36,7 +36,7 @@ defmodule Freight.UnitTests.Integrations.EctoTest do
         })
         |> Integrations.Ecto.convert_error()
 
-      assert errors == ["age is invalid"]
+      assert errors == ["You are not old enough!"]
     end
 
     test "succeeds with multiple changeset errors" do
@@ -46,7 +46,7 @@ defmodule Freight.UnitTests.Integrations.EctoTest do
         })
         |> Integrations.Ecto.convert_error()
 
-      assert errors = ["email can't be blank", "name can't be blank"]
+      assert errors == ["email can't be blank", "name can't be blank"]
     end
 
     test "successfully deals with variables in changeset errors" do


### PR DESCRIPTION
Currently,

```elixir
changeset
|> validate_inclusion(:age, 21..100, message: "You are not old enough!")
```

Generates an error payload with the error `"age You are not old enough!"`. This is unexpected behavior, as custom messages do not always follow the same pattern as default errors from Ecto have.

Because custom messages are never stored in the changeset struct, but are applied on calling the `validate_x` method, there is no easy way for us to know when someone defined a custom error. The current solution is able to recognize whether something is a default message albeit a bit hacky.

### Todos
~- [ ] Write tests for all cases, to ensure Ecto updates won't break error messages~

### Fixes
Fixes: #11
